### PR TITLE
Allow instances to be started in a different set of subnets to the NLB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,15 @@ Any changes to the S3 bucket will be synchronised within 5 minutes
 | Variable | Description | Type | Required | Default |
 |----------|-------------|:----:|:--------:|:-------:|
 | region | AWS region name | string | yes | |
-| subnet_arns | List of public subnet ARNs where instances will be deployed. | list | yes | |
+| public_subnet_arns | List of public subnet ARNs where NLB listeners will be deployed. | list | yes | |
+| instance_subnet_arns | List of subnet ARNs where instances will be deployed. | list | yes | |
 | vpc_id | ID of the VPC where the bastion will be deployed | string | yes | |
 | admin_ssh_key_pair | Name of the SSH key pair for the admin user account | string | yes | |
 | name_prefix | Prefix to be applied to names of all resources | string | no | `bastion-host-` |
 | external_allowed_cidrs | List of CIDRs which can access the bastion | list | no | `["0.0.0.0/0"]` |
 | external_ssh_port | Which port to use to SSH into the bastion | number | no | `22` |
 | internal_ssh_port | Which port the bastion will use to SSH into other private instances | number | no | `22` |
-| instance_count | Number of instances to deploy. Defaults to one per subnet ARN provided. | number | no | `count(var.subnet_arns)` |
+| instance_count | Number of instances to deploy. Defaults to one per subnet ARN provided. | number | no | `count(var.instance_subnet_arns)` |
 | custom_ami | Provide your own AWS AMI to use - useful if you need specific tools on the bastion | string | no | |
 | dns_config | Optional details of an alias DNS record for the bastion. [See below](#dns-config) for properties | object | no | |
 | tags_default | Tags to apply to all resources | map | no | `{}` |

--- a/elb.tf
+++ b/elb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "bastion" {
   name_prefix = "${var.name_prefix}lb-"
   internal    = false
 
-  subnets = var.subnet_arns
+  subnets = var.public_subnet_arns
 
   load_balancer_type = "network"
   tags               = merge(map("Name", "${var.name_prefix}lb"), var.tags_default, var.tags_lb)

--- a/init.sh
+++ b/init.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
+set -xe
+
 yum -y update --security
 yum -y install jq
 
-cat > /usr/bin/bastion/sync_users_with_s3 << EOF
+mkdir /usr/bin/bastion
+mkdir /var/log/bastion
+
+cat > /usr/bin/bastion/sync_users_with_s3 <<'EOF'
 #!/usr/bin/env bash
+
+set -xe
 
 LOG_FILE="/var/log/bastion/changelog.log"
 # Where we store etags of public keys for registered users

--- a/instance.tf
+++ b/instance.tf
@@ -31,11 +31,28 @@ resource "aws_security_group" "bastion" {
     cidr_blocks = concat(data.aws_subnet.subnets.*.cidr_block, var.external_allowed_cidrs)
   }
 
-  # Outgoing traffic - allow internet egress for yum updates
+  # Outgoing traffic - anything VPC only
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
+    cidr_blocks = [data.aws_vpc.bastion.cidr_block]
+  }
+
+  # Plus allow HTTP(S) internet egress for yum updates
+  egress {
+    description = "Outbound TLS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Outbound HTTP"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
 }

--- a/instance.tf
+++ b/instance.tf
@@ -31,12 +31,12 @@ resource "aws_security_group" "bastion" {
     cidr_blocks = concat(data.aws_subnet.subnets.*.cidr_block, var.external_allowed_cidrs)
   }
 
-  # Outgoing traffic - restrict to the VPC
+  # Outgoing traffic - allow internet egress for yum updates
   egress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = [data.aws_vpc.bastion.cidr_block]
+    cidr_blocks = ["0.0.0.0/0"]
   }
 }
 
@@ -85,7 +85,7 @@ resource "aws_autoscaling_group" "bastion" {
   min_size             = local.instance_count
   desired_capacity     = local.instance_count
 
-  vpc_zone_identifier = var.subnet_arns
+  vpc_zone_identifier = var.instance_subnet_arns
 
   default_cooldown          = 180
   health_check_grace_period = 180

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # IPv4 and IPv6 record types will be created
   dns_record_types = ["A", "AAAA"]
 
-  instance_count = var.instance_count != -1 ? var.instance_count : length(var.subnet_arns)
+  instance_count = var.instance_count != -1 ? var.instance_count : length(var.instance_subnet_arns)
 }
 
 data "aws_vpc" "bastion" {
@@ -10,6 +10,6 @@ data "aws_vpc" "bastion" {
 }
 
 data "aws_subnet" "subnets" {
-  count = length(var.subnet_arns)
-  id    = var.subnet_arns[count.index]
+  count = length(var.public_subnet_arns)
+  id    = var.public_subnet_arns[count.index]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -2,8 +2,12 @@ variable "region" {
   description = "AWS region name"
 }
 
-variable "subnet_arns" {
-  description = "List of subnet ARNs where instances will be deployed. This should have public ingress"
+variable "public_subnet_arns" {
+  description = "List of subnet ARNs where NLB listeners will be deployed. This should have public ingress"
+}
+
+variable "instance_subnet_arns" {
+  description = "List of subnet ARNs where instances will be deployed."
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
Allow instances to be started in a different set of subnets to the NLB.
Also fix init script by allowing internet egress and fixing syntax:
 * Add internet egress rule
 * Create missing folders for files to be written to
 * Add quotes around EOF in HEREDOC - prevents interpretation of $VARs

I've tested this in our dev env and it all seems to be working!