### PR TITLE
Input and output variable tidy up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 *.tfstate
 *.tfstate.*
 
+# Lock file - not used for modules
+.terraform.lock.hcl
+
 # Crash log files
 crash.log
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Any changes to the S3 bucket will be synchronised within 5 minutes
 
 ## Outputs
 
-| Variable | Description | 
+| Variable | Description |
 |----------|-------------|
-| instances_security_group_id | Security group to apply to specific instances to allow ingress from the bastion | 
-| bastion_dns_name | DNS name of the bastion. | 
+| bastion_security_group_id | Security group of the bastion instances |
+| bastion_dns_name | DNS name of the bastion. |
 | ssh_keys_bucket | Name of the S3 bucket used for user public key storage |

--- a/README.md
+++ b/README.md
@@ -20,15 +20,15 @@ Any changes to the S3 bucket will be synchronised within 5 minutes
 | Variable | Description | Type | Required | Default |
 |----------|-------------|:----:|:--------:|:-------:|
 | region | AWS region name | string | yes | |
-| public_subnet_arns | List of public subnet ARNs where NLB listeners will be deployed. | list | yes | |
-| instance_subnet_arns | List of subnet ARNs where instances will be deployed. | list | yes | |
+| public_subnet_ids | List of public subnet ARNs where NLB listeners will be deployed. | list | yes | |
+| instance_subnet_ids | List of subnet ARNs where instances will be deployed. | list | yes | |
 | vpc_id | ID of the VPC where the bastion will be deployed | string | yes | |
-| admin_ssh_key_pair | Name of the SSH key pair for the admin user account | string | yes | |
+| admin_ssh_key_pair_name | Name of the SSH key pair for the admin user account | string | yes | |
 | name_prefix | Prefix to be applied to names of all resources | string | no | `bastion-host-` |
 | external_allowed_cidrs | List of CIDRs which can access the bastion | list | no | `["0.0.0.0/0"]` |
 | external_ssh_port | Which port to use to SSH into the bastion | number | no | `22` |
 | internal_ssh_port | Which port the bastion will use to SSH into other private instances | number | no | `22` |
-| instance_count | Number of instances to deploy. Defaults to one per subnet ARN provided. | number | no | `count(var.instance_subnet_arns)` |
+| instance_count | Number of instances to deploy. Defaults to one per subnet ARN provided. | number | no | `count(var.instance_subnet_ids)` |
 | custom_ami | Provide your own AWS AMI to use - useful if you need specific tools on the bastion | string | no | |
 | dns_config | Optional details of an alias DNS record for the bastion. [See below](#dns-config) for properties | object | no | |
 | tags_default | Tags to apply to all resources | map | no | `{}` |

--- a/elb.tf
+++ b/elb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "bastion" {
   name_prefix = "${var.name_prefix}lb-"
   internal    = false
 
-  subnets = var.public_subnet_arns
+  subnets = var.public_subnet_ids
 
   load_balancer_type = "network"
   tags               = merge({"Name" = "${var.name_prefix}lb"}, var.tags_default, var.tags_lb)

--- a/instance.tf
+++ b/instance.tf
@@ -60,8 +60,8 @@ resource "aws_security_group" "bastion" {
 resource "aws_launch_configuration" "bastion" {
   name_prefix = "${var.name_prefix}launch-config-"
   image_id    = var.custom_ami != "" ? var.custom_ami : data.aws_ami.aws_linux_2[0].image_id
-  # A t2.nano should be perfectly sufficient for a simple bastion host
-  instance_type               = "t2.nano"
+  # A t3.nano should be perfectly sufficient for a simple bastion host
+  instance_type               = "t3.nano"
   associate_public_ip_address = false
   enable_monitoring           = true
   iam_instance_profile        = aws_iam_instance_profile.bastion_host_profile.name

--- a/instance.tf
+++ b/instance.tf
@@ -81,7 +81,7 @@ resource "aws_launch_configuration" "bastion" {
   associate_public_ip_address = false
   enable_monitoring           = true
   iam_instance_profile        = aws_iam_instance_profile.bastion_host_profile.name
-  key_name                    = var.admin_ssh_key_pair
+  key_name                    = var.admin_ssh_key_pair_name
 
   security_groups = [aws_security_group.bastion.id]
 
@@ -102,7 +102,7 @@ resource "aws_autoscaling_group" "bastion" {
   min_size             = local.instance_count
   desired_capacity     = local.instance_count
 
-  vpc_zone_identifier = var.instance_subnet_arns
+  vpc_zone_identifier = var.instance_subnet_ids
 
   default_cooldown          = 180
   health_check_grace_period = 180

--- a/instance.tf
+++ b/instance.tf
@@ -57,22 +57,6 @@ resource "aws_security_group" "bastion" {
   }
 }
 
-resource "aws_security_group" "instances" {
-  description = "Apply this group to specific instances to allow SSH ingress from the bastion"
-  name        = "${var.name_prefix}instances"
-  vpc_id      = var.vpc_id
-
-  tags = merge({"Name" = "${var.name_prefix}instances"}, var.tags_default, var.tags_sg)
-
-  # Incoming traffic from the internet. Only allow SSH connections
-  ingress {
-    from_port       = var.internal_ssh_port
-    to_port         = var.internal_ssh_port
-    protocol        = "TCP"
-    security_groups = [aws_security_group.bastion.id]
-  }
-}
-
 resource "aws_launch_configuration" "bastion" {
   name_prefix = "${var.name_prefix}launch-config-"
   image_id    = var.custom_ami != "" ? var.custom_ami : data.aws_ami.aws_linux_2[0].image_id

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   # IPv4 and IPv6 record types will be created
   dns_record_types = ["A", "AAAA"]
 
-  instance_count = var.instance_count != -1 ? var.instance_count : length(var.instance_subnet_arns)
+  instance_count = var.instance_count != -1 ? var.instance_count : length(var.instance_subnet_ids)
 }
 
 data "aws_vpc" "bastion" {
@@ -10,6 +10,6 @@ data "aws_vpc" "bastion" {
 }
 
 data "aws_subnet" "subnets" {
-  count = length(var.public_subnet_arns)
-  id    = var.public_subnet_arns[count.index]
+  count = length(var.public_subnet_ids)
+  id    = var.public_subnet_ids[count.index]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,6 @@
-output "instances_security_group_id" {
-  value = aws_security_group.instances.id
+output "bastion_security_group_id" {
+  description = "Security group of the bastion instances"
+  value = aws_security_group.bastion.id
 }
 
 output "bastion_dns_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -2,19 +2,19 @@ variable "region" {
   description = "AWS region name"
 }
 
-variable "public_subnet_arns" {
-  description = "List of subnet ARNs where NLB listeners will be deployed. This should have public ingress"
+variable "public_subnet_ids" {
+  description = "List of subnet ids where NLB listeners will be deployed. This should have public ingress"
 }
 
-variable "instance_subnet_arns" {
-  description = "List of subnet ARNs where instances will be deployed."
+variable "instance_subnet_ids" {
+  description = "List of subnet ids where instances will be deployed"
 }
 
 variable "vpc_id" {
   description = "ID of the VPC where the bastion will be deployed"
 }
 
-variable "admin_ssh_key_pair" {
+variable "admin_ssh_key_pair_name" {
   description = "Name of the SSH key pair for the admin user account"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -19,8 +19,13 @@ variable "admin_ssh_key_pair_name" {
 }
 
 variable "name_prefix" {
-  description = "Prefix to be applied to names of all resources"
-  default     = "bastion-host-"
+  description = "Max 3 character prefix to be applied to names of all resources"
+  default     = "bst"
+
+  validation {
+    condition     = length(var.name_prefix) <= 3
+    error_message = "name_prefix must be at most three characters"
+  }
 }
 
 variable "external_allowed_cidrs" {


### PR DESCRIPTION
Tidy up some input and output variables, and update the instance type to t3.nano (from t2.nano).

This is a breaking change as it updates some variable names, but they hopefully won't be controversial. LNER is the only project that I know of using this, and it pins a commit hash, so can be updated (or not) whenever.